### PR TITLE
Compatibility with windows

### DIFF
--- a/R/parser-general.R
+++ b/R/parser-general.R
@@ -135,7 +135,7 @@ parse_features <- function(x, seqinfo) {
   ftbl <- parallel::mcmapply(
     gbFeature, feature = fl, id = id,
     MoreArgs = list(accession = getAccession(seqinfo)[1]),
-    SIMPLIFY = FALSE, USE.NAMES = FALSE, mc.cores = mc_cores
+    SIMPLIFY = FALSE, USE.NAMES = FALSE, mc.cores = 1
   )                   
   S4Vectors::new2('gbFeatureTable', .Data = ftbl, .id = id, .seqinfo = seqinfo, check = FALSE) 
 }

--- a/R/parser-general.R
+++ b/R/parser-general.R
@@ -169,7 +169,7 @@ join_seq <- function(seq, acc, src = c("gbk", "embl")) {
   mc_cores <- floor(parallel::detectCores()*0.75)
   s <- unlist(parallel::mclapply(seq, function(x) {
     paste0(strsplit(.substr(x), ' ')[[1L]], collapse = '')
-  }, mc.cores = mc_cores))
+  }, mc.cores = 1))
   s <- c(paste0(">", acc), s)
   s
 }

--- a/R/parser-general.R
+++ b/R/parser-general.R
@@ -130,12 +130,14 @@ make_progress_bar <- function(n) {
 parse_features <- function(x, seqinfo) {
   feature_start <- which(substr(x, 6, 6) != " ")
   fl <- ixsplit(x, feature_start)
-  mc_cores <- floor(parallel::detectCores()*0.75)
+  mc_cores <- ifelse(Sys.info()['sysname'] == "Windows",
+                     1,
+                     floor(parallel::detectCores()*0.75))
   id <- seq_along(feature_start)
   ftbl <- parallel::mcmapply(
     gbFeature, feature = fl, id = id,
     MoreArgs = list(accession = getAccession(seqinfo)[1]),
-    SIMPLIFY = FALSE, USE.NAMES = FALSE, mc.cores = 1
+    SIMPLIFY = FALSE, USE.NAMES = FALSE, mc.cores = mc_cores
   )                   
   S4Vectors::new2('gbFeatureTable', .Data = ftbl, .id = id, .seqinfo = seqinfo, check = FALSE) 
 }
@@ -166,10 +168,12 @@ join_seq <- function(seq, acc, src = c("gbk", "embl")) {
                     gbk  = Partial('substr', start = 11, stop = 75),
                     embl = Partial('substr', start = 6, stop = 70)
   )
-  mc_cores <- floor(parallel::detectCores()*0.75)
+  mc_cores <- ifelse(Sys.info()['sysname'] == "Windows",
+                     1,
+                     floor(parallel::detectCores()*0.75))
   s <- unlist(parallel::mclapply(seq, function(x) {
     paste0(strsplit(.substr(x), ' ')[[1L]], collapse = '')
-  }, mc.cores = 1))
+  }, mc.cores = mc_cores))
   s <- c(paste0(">", acc), s)
   s
 }


### PR DESCRIPTION
gbRecord() can't work on Windows because mc.cores must be 1 on Windows.